### PR TITLE
Memory is freed for the parent process (child is leaking when execve fails though)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -Werror -Wextra -pedantic
 EXEC_FILE = shell
-C_FILES = main.c print_char.c print_env.c find_path.c concat_strings.c free_grid.c change_dir.c
+C_FILES = main.c print_char.c print_env.c find_path.c concat_strings.c free_grid.c change_dir.c str_len.c grid_size.c print_prompt.c str_cmp.c
 OBJECTS	:= $(C_FILES:.c=.o)
 
 $(EXEC_FILE): $(OBJECTS) libshell/libshell.a

--- a/find_path.c
+++ b/find_path.c
@@ -40,7 +40,7 @@ char *find_path(char *cmd, char **env) {
         for(i = 0; arr[i] != '\0'; ++i) {
                 dir = opendir(arr[i]);
                 while((dir_search = readdir(dir)) != NULL) {
-                        if (strcmp(dir_search->d_name, cmd) == 0) {
+                        if (str_cmp(dir_search->d_name, cmd) == 0) {
                                 arr[i] = concat_strings(arr[i], "/");
                                 return concat_strings(arr[i], cmd);
                         }
@@ -72,7 +72,7 @@ char *get_env_var(char *var, char **env) {
         for(loc = 0; env[loc] != '\0'; loc++) {
                 for(j = 0; j < len; ++j) {
                         var_str[j] = env[loc][j];
-                } if(strcmp(var, var_str) == 0)
+                } if(str_cmp(var, var_str) == 0)
                         break;
                 if(env[loc + 1] == '\0')
                         return NULL;

--- a/grid_size.c
+++ b/grid_size.c
@@ -1,0 +1,15 @@
+/* determines size of a grid of characters (array of strings) */
+int grid_size(char **grid)
+{
+	int i;
+
+	i = 0;
+
+	while (*grid != 0) 	/* until there is no pointer */
+	{
+		i++;	     /* increase counter */
+		grid++;     /* pointer arithmetic for next pointer */
+	}
+
+	return i;
+}

--- a/header.h
+++ b/header.h
@@ -1,7 +1,7 @@
 int print_char(char);
 char *concat_strings(char *, char *);
 int str_len(char *);
-int strcmp(char *, char *);
+int str_cmp(char *, char *);
 int *print_prompt();
 void print_env(char **);
 char *find_path(char *, char **);

--- a/main.c
+++ b/main.c
@@ -40,13 +40,13 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 
 	/* memory leak is happening inside this if statement */
 	if (strcmp(exec_argv[0], "exit") != 0) {
-		exec_argv[0] = concat_strings("/bin/", exec_argv[0]);
-
 		if ((pid = fork()) == -1) {
 			perror("fork");
 			return 1;
 		} else if (pid == 0) {
+			exec_argv[0] = concat_strings("/bin/", exec_argv[0]);
 			execve(exec_argv[0], exec_argv, env);
+			free_grid(exec_argv, exec_size);
 		} else {
 			wait(&status);
 		}

--- a/main.c
+++ b/main.c
@@ -46,11 +46,11 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 			return 1;
 		} else if (pid == 0) {
 			exec_argv[0] = concat_strings("/bin/", exec_argv[0]);
-			if (execve(exec_argv[0], exec_argv, env) == -1)
-			{
-				perror("execve");
-				return 2;
-			}
+			execve(exec_argv[0], exec_argv, env);
+			perror("execve");
+			free_grid(exec_argv, exec_size);
+			return -1; /* child process returns this */
+		
 		} else {
 			wait(&status);
 		}

--- a/main.c
+++ b/main.c
@@ -38,7 +38,7 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 		exec_size = grid_size(exec_argv); /* how many strings in the array */
 		/* printf("Size of exec_argv: %d\n", exec_size); */
 
-		if (strcmp(exec_argv[0], "exit") == 0)
+		if (str_cmp(exec_argv[0], "exit") == 0)
 			break;
 
 		if ((pid = fork()) == -1) {
@@ -59,62 +59,4 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 
 	free_grid(exec_argv, exec_size);
 	return 0;
-}
-
-int str_len(char *str)
-{
-	int i;			/* i used as a counter */
-
-	i = 0;			/* initialize at 0 */
-
-	while (*str != '\0')	/* while string isn't over */
-	{
-		i++;		/* increase counter */
-		str++;		/* pointer arithmetic for next char */
-	}
-
-	return i;
-}
-
-/* determines size of a grid of characters (array of strings) */
-int grid_size(char **grid)
-{
-	int i;
-
-	i = 0;
-
-	while (*grid != NULL) 	/* until there is no pointer */
-	{
-		i++;	     /* increase counter */
-		grid++;     /* pointer arithmetic for next pointer */
-	}
-
-	return i;
-}
-
-int *print_prompt(){
-	int i;
-	char *prompt = "GreenShell$ ";
-
-	i = 0;
-	while (prompt[i] != '\0') {
-		print_char(prompt[i]);
-		++i;
-	}
-	return 0;
-}
-
-int strcmp(char *s1, char *s2)
-{
-	int i = 0;
-	int j = 0;
-	for ( ; s1[i] != '\0'; i++)
-	{
-		if (s1[j] != s2[j]) /* if chars are different, break */
-		{
-			break;
-		}
-		j++;
-	}
-	return(s1[j] - s2[j]); /* return difference in chars */
 }

--- a/main.c
+++ b/main.c
@@ -30,45 +30,51 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 		return 1;
 	}
 
-	print_prompt();
-	raw_str = read_line(0);
-	exec_argv = string_split(raw_str, ' ');
-	free(raw_str); 	/* frees the memory allocated in read_line() */
-	exec_size = grid_size(exec_argv); /* how many strings in the array */
-	/* printf("Size of exec_argv: %d\n", exec_size); */
+	while (1) {
+		print_prompt();
+		raw_str = read_line(0);
+		exec_argv = string_split(raw_str, ' ');
+		free(raw_str); 	/* frees the memory allocated in read_line() */
+		exec_size = grid_size(exec_argv); /* how many strings in the array */
+		/* printf("Size of exec_argv: %d\n", exec_size); */
 
-	/* memory leak is happening inside this if statement */
-	if (strcmp(exec_argv[0], "exit") != 0) {
+		if (strcmp(exec_argv[0], "exit") == 0)
+			break;
+
 		if ((pid = fork()) == -1) {
 			perror("fork");
 			return 1;
 		} else if (pid == 0) {
 			exec_argv[0] = concat_strings("/bin/", exec_argv[0]);
-			execve(exec_argv[0], exec_argv, env);
-			free_grid(exec_argv, exec_size);
+			if (execve(exec_argv[0], exec_argv, env) == -1)
+			{
+				perror("execve");
+				return 2;
+			}
 		} else {
 			wait(&status);
 		}
+
+		free_grid(exec_argv, exec_size);
 	}
 
 	free_grid(exec_argv, exec_size);
-
 	return 0;
 }
 
 int str_len(char *str)
 {
-        int i;			/* i used as a counter */
+	int i;			/* i used as a counter */
 
-        i = 0;			/* initialize at 0 */
+	i = 0;			/* initialize at 0 */
 
-        while (*str != '\0')	/* while string isn't over */
-        {
-                i++;		/* increase counter */
-                str++;		/* pointer arithmetic for next char */
-        }
+	while (*str != '\0')	/* while string isn't over */
+	{
+		i++;		/* increase counter */
+		str++;		/* pointer arithmetic for next char */
+	}
 
-        return i;
+	return i;
 }
 
 /* determines size of a grid of characters (array of strings) */
@@ -78,25 +84,25 @@ int grid_size(char **grid)
 
 	i = 0;
 
-        while (*grid != NULL) 	/* until there is no pointer */
-        {
-                i++;	     /* increase counter */
-                grid++;     /* pointer arithmetic for next pointer */
-        }
+	while (*grid != NULL) 	/* until there is no pointer */
+	{
+		i++;	     /* increase counter */
+		grid++;     /* pointer arithmetic for next pointer */
+	}
 
 	return i;
 }
 
 int *print_prompt(){
-        int i;
-        char *prompt = "GreenShell$ ";
+	int i;
+	char *prompt = "GreenShell$ ";
 
-        i = 0;
-        while (prompt[i] != '\0') {
-                print_char(prompt[i]);
-                ++i;
-        }
-        return 0;
+	i = 0;
+	while (prompt[i] != '\0') {
+		print_char(prompt[i]);
+		++i;
+	}
+	return 0;
 }
 
 int strcmp(char *s1, char *s2)

--- a/main.c
+++ b/main.c
@@ -26,10 +26,9 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 	char **exec_argv;
 	int exec_size; 		/* how many strings in the array */
 
-	if (argc != 1) {
+	if (argc != 1) { 	/* usage */
 		return 1;
 	}
-  
 
 	print_prompt();
 	raw_str = read_line(0);

--- a/main.c
+++ b/main.c
@@ -36,7 +36,7 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 	exec_argv = string_split(raw_str, ' ');
 	free(raw_str); 	/* frees the memory allocated in read_line() */
 	exec_size = grid_size(exec_argv); /* how many strings in the array */
-	printf("Size of exec_argv: %d\n", exec_size);
+	/* printf("Size of exec_argv: %d\n", exec_size); */
 
 	/* memory leak is happening inside this if statement */
 	if (strcmp(exec_argv[0], "exit") != 0) {

--- a/main.c
+++ b/main.c
@@ -45,12 +45,11 @@ int main(int argc, __attribute__((unused)) char **argv, char **env) {
 			perror("fork");
 			return 1;
 		} else if (pid == 0) {
-			exec_argv[0] = concat_strings("/bin/", exec_argv[0]);
-			execve(exec_argv[0], exec_argv, env);
+			execve(raw_str = concat_strings("/bin/", exec_argv[0]), exec_argv, env);
 			perror("execve");
+			free(raw_str);
 			free_grid(exec_argv, exec_size);
 			return -1; /* child process returns this */
-		
 		} else {
 			wait(&status);
 		}

--- a/main.c
+++ b/main.c
@@ -19,41 +19,42 @@
  */
 int main(int argc, __attribute__((unused)) char **argv, char **env) {
 
-        pid_t pid;
-        int status;
-        /*char *path_to_exec;*/
-        char *raw_str;
-        char **exec_argv;
+	pid_t pid;
+	int status;
+	/*char *path_to_exec;*/
+	char *raw_str;
+	char **exec_argv;
 	int exec_size; 		/* how many strings in the array */
 
-        if (argc != 1) {
+	if (argc != 1) {
 		return 1;
-        }
+	}
+  
 
-        while (1) {
-                print_prompt();
-                raw_str = read_line(0);
-                exec_argv = string_split(raw_str, ' ');
-		free(raw_str); 	/* frees the memory allocated in read_line() */
+	print_prompt();
+	raw_str = read_line(0);
+	exec_argv = string_split(raw_str, ' ');
+	free(raw_str); 	/* frees the memory allocated in read_line() */
+	exec_size = grid_size(exec_argv); /* how many strings in the array */
+	printf("Size of exec_argv: %d\n", exec_size);
 
-                if (strcmp(exec_argv[0], "exit") == 0)
-                        return 0;
+	/* memory leak is happening inside this if statement */
+	if (strcmp(exec_argv[0], "exit") != 0) {
+		exec_argv[0] = concat_strings("/bin/", exec_argv[0]);
 
-                exec_argv[0] = concat_strings("/bin/",exec_argv[0]);
+		if ((pid = fork()) == -1) {
+			perror("fork");
+			return 1;
+		} else if (pid == 0) {
+			execve(exec_argv[0], exec_argv, env);
+		} else {
+			wait(&status);
+		}
+	}
 
-                if ((pid = fork()) == -1) {
-                        perror("fork");
-                        return 1;
-                } else if (pid == 0) {
-                        execve(exec_argv[0], exec_argv, env);
-                } else {
-                        wait(&status);
-			exec_size = grid_size(exec_argv); /* how many strings in the array */
-			printf("Size of exec_argv: %d\n", exec_size);
-                }
-        }
+	free_grid(exec_argv, exec_size);
 
-        return 0;
+	return 0;
 }
 
 int str_len(char *str)

--- a/print_prompt.c
+++ b/print_prompt.c
@@ -1,0 +1,13 @@
+#include "header.h"
+
+int *print_prompt(){
+	int i;
+	char *prompt = "GreenShell$ ";
+
+	i = 0;
+	while (prompt[i] != '\0') {
+		print_char(prompt[i]);
+		++i;
+	}
+	return 0;
+}

--- a/str_cmp.c
+++ b/str_cmp.c
@@ -1,0 +1,14 @@
+int str_cmp(char *s1, char *s2)
+{
+	int i = 0;
+	int j = 0;
+	for ( ; s1[i] != '\0'; i++)
+	{
+		if (s1[j] != s2[j]) /* if chars are different, break */
+		{
+			break;
+		}
+		j++;
+	}
+	return(s1[j] - s2[j]); /* return difference in chars */
+}

--- a/str_len.c
+++ b/str_len.c
@@ -1,0 +1,14 @@
+int str_len(char *str)
+{
+	int i;			/* i used as a counter */
+
+	i = 0;			/* initialize at 0 */
+
+	while (*str != '\0')	/* while string isn't over */
+	{
+		i++;		/* increase counter */
+		str++;		/* pointer arithmetic for next char */
+	}
+
+	return i;
+}


### PR DESCRIPTION
Idk what's up with all the whitespace.
Anyway, run it with valgrind. Upon exiting via "exit" command, all memory should be freed.
